### PR TITLE
[GITHUB-2] Allow to generate passwd config file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 .vagrant
 /tests/vagrant/ansible-city.*
+*.bak

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,6 @@
 
+BRANCH?=$(shell git rev-parse --abbrev-ref HEAD)
+
 all: test clean
 
 test: test_deps vagrant_up
@@ -10,8 +12,13 @@ test_deps:
 	ln -s ../.. tests/vagrant/ansible-city.gocd_server
 	ansible-galaxy install --force -p tests/vagrant -r tests/vagrant/local_requirements.yml
 
-integration_test:
-	ansible-galaxy install --force -p tests/vagrant -r tests/vagrant/integration_requirements.yml
+integration_test_deps:
+	sed -i.bak \
+		-E 's/(.*)version: (.*)/\1version: origin\/$(BRANCH)/' \
+		tests/vagrant/integration_requirements.yml
+	rm -rf tests/vagrant/ansible-city.*
+	ansible-galaxy install -p tests/vagrant -r tests/vagrant/integration_requirements.yml
+	mv tests/vagrant/integration_requirements.yml.bak tests/vagrant/integration_requirements.yml
 
 vagrant_up:
 	@cd tests/vagrant; \

--- a/Makefile
+++ b/Makefile
@@ -22,6 +22,11 @@ vagrant_up:
 		vagrant up || exit 1; \
 	fi;
 
+vagrant_ssh:
+	@cd tests/vagrant; \
+	vagrant up || exit 1; \
+	vagrant ssh
+
 clean:
 	rm -rf tests/vagrant/ansible-city.*
 	cd tests/vagrant && vagrant destroy

--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ To simply install GO CD server:
 
   pre_tasks:
     - name: Update apt
-      sudo: yes
+      become: yes
       command: apt-get update
       tags:
         - build
@@ -79,7 +79,7 @@ A bit more advanced playbook to install on a box with more then 4GB ram:
 
   pre_tasks:
     - name: Update apt
-      sudo: yes
+      become: yes
       command: apt-get update
       tags:
         - build
@@ -102,14 +102,14 @@ A bit more advanced playbook to install on a box with more then 4GB ram:
 
   pre_tasks:
     - name: Update apt
-      sudo: yes
+      become: yes
       command: apt-get update
       tags:
         - build
 
   roles:
-    - role: my-own.java
-    - role: ansible-city.gocd_server
+    - name: my-own.java
+    - name: ansible-city.gocd_server
       gocd_server:
         dependencies:
           skip_java: yes
@@ -124,13 +124,13 @@ To **generate passwd file** you have to specify a dictionary of
 
   pre_tasks:
     - name: Update apt
-      sudo: yes
+      become: yes
       command: apt-get update
       tags:
         - build
 
   roles:
-    - role: ansible-city.gocd_server
+    - name: ansible-city.gocd_server
       gocd_server:
         passwd_users:
           test.user: "{SHA}iCKdyZxzuc4lU6CCoqsp4H99608="

--- a/README.md
+++ b/README.md
@@ -114,3 +114,24 @@ A bit more advanced playbook to install on a box with more then 4GB ram:
         dependencies:
           skip_java: yes
 ```
+
+To **generate passwd file** you have to specify a dictionary of
+`username:sha-passwd`
+
+```YAML
+- name: Install GO CD Server
+  hosts: sandbox
+
+  pre_tasks:
+    - name: Update apt
+      sudo: yes
+      command: apt-get update
+      tags:
+        - build
+
+  roles:
+    - role: ansible-city.gocd_server
+      gocd_server:
+        passwd_users:
+          test.user: "{SHA}iCKdyZxzuc4lU6CCoqsp4H99608="
+```

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,20 +1,19 @@
 ---
 
 gocd_server:
-  version: "14.4.*"
-
   group: go
-  user: go
-  user_dir: /home/go
-
   java_home: /usr/lib/jvm/java-7-oracle/jre
-  port: 8153
   port_ssl: 8154
-
+  port: 8153
   server_max_mem: 512m
   server_max_perm_gen: 128m
   server_mem: 256m
   server_min_perm_gen: 128m
+  user_dir: /home/go
+  user: go
+  version: "14.4.*"
 
   dependencies:
     skip_java: no
+
+  passwd_users: { }

--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -1,19 +1,19 @@
 ---
 
 - name: start go-server
-  sudo: yes
+  become: yes
   service:
     name: go-server
     state: started
 
 - name: stop go-server
-  sudo: yes
+  become: yes
   service:
     name: go-server
     state: stopped
 
 - name: restart go-server
-  sudo: yes
+  become: yes
   service:
     name: go-server
     state: restarted

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -4,18 +4,19 @@ galaxy_info:
   author: "Wojtek Oledzki"
   description: "Install the Go Continuous Delivery server."
   license: MIT
-  min_ansible_version: 1.8
+  min_ansible_version: 1.9
   platforms:
     - name: Ubuntu
       versions:
         - all
   categories:
     - development
+    - cd
 
 dependencies:
-  - role: ansible-city.java
-    name: ansible-city.java
-    src: git+git@github.com:ansible-city/java.git
+  - name: ansible-city.java
+    src: https://github.com/ansible-city/java.git
+    scm: git
     tags:
       - build
     when: not gocd_server.dependencies.skip_java

--- a/tasks/build.yml
+++ b/tasks/build.yml
@@ -1,12 +1,18 @@
 ---
 
-- name: add go group
+- name: Ensure hostname is resolvable
+  sudo: yes
+  lineinfile:
+    dest: /etc/hosts
+    line: "127.0.0.1 {{ ansible_hostname }}"
+
+- name: Ensure go group
   sudo: yes
   group:
     name: "{{ gocd_server.group }}"
     state: present
 
-- name: add go user with home at /var/go
+- name: Ensure go user
   sudo: yes
   user:
     name: "{{ gocd_server.user }}"
@@ -28,16 +34,16 @@
     repo: deb http://dl.bintray.com/gocd/gocd-deb/ /
     state: present
 
-- name: install go-server
+- name: Install go-server
   sudo: yes
   apt:
     name: "go-server={{ gocd_server.version }}"
     state: present
     force: yes
 
-- name: enable go-server
+- name: Add go-server to autostart
   sudo: yes
   service:
     name: go-server
     enabled: yes
-    state: started
+    state: stopped

--- a/tasks/build.yml
+++ b/tasks/build.yml
@@ -1,19 +1,19 @@
 ---
 
 - name: Ensure hostname is resolvable
-  sudo: yes
+  become: yes
   lineinfile:
     dest: /etc/hosts
     line: "127.0.0.1 {{ ansible_hostname }}"
 
 - name: Ensure go group
-  sudo: yes
+  become: yes
   group:
     name: "{{ gocd_server.group }}"
     state: present
 
 - name: Ensure go user
-  sudo: yes
+  become: yes
   user:
     name: "{{ gocd_server.user }}"
     comment: Go CD User
@@ -21,7 +21,7 @@
     home: "{{ gocd_server.user_dir }}"
 
 - name: Install some dependencies
-  sudo: yes
+  become: yes
   apt:
     name: "{{ item }}"
   with_items:
@@ -29,20 +29,20 @@
     - tree
 
 - name: add GO CD apt repository
-  sudo: yes
+  become: yes
   apt_repository:
     repo: deb http://dl.bintray.com/gocd/gocd-deb/ /
     state: present
 
 - name: Install go-server
-  sudo: yes
+  become: yes
   apt:
     name: "go-server={{ gocd_server.version }}"
     state: present
     force: yes
 
 - name: Add go-server to autostart
-  sudo: yes
+  become: yes
   service:
     name: go-server
     enabled: yes

--- a/tasks/configure.yml
+++ b/tasks/configure.yml
@@ -1,7 +1,7 @@
 ---
 
 - name: create various directories
-  sudo: yes
+  become: yes
   file:
     path: "{{ gocd_server.user_dir }}/{{ item }}"
     state: directory
@@ -11,7 +11,7 @@
     - work/go-server
 
 - name: Ensures go-server configuration
-  sudo: yes
+  become: yes
   template:
     src: defaults.j2
     dest: /etc/default/go-server
@@ -21,7 +21,7 @@
     - restart go-server
 
 - name: Ensures go-server passwd file
-  sudo: yes
+  become: yes
   template:
     src: passwd.j2
     dest: "{{ gocd_server.user_dir }}/passwd"
@@ -31,7 +31,7 @@
   when: gocd_server.passwd_users
 
 - name: Ensure gocd server is running
-  sudo: yes
+  become: yes
   service:
     name: go-server
     state: started

--- a/tasks/configure.yml
+++ b/tasks/configure.yml
@@ -19,3 +19,19 @@
     group: "{{ gocd_server.group }}"
   notify:
     - restart go-server
+
+- name: Ensures go-server passwd file
+  sudo: yes
+  template:
+    src: passwd.j2
+    dest: "{{ gocd_server.user_dir }}/passwd"
+    owner: "{{ gocd_server.user }}"
+    group: "{{ gocd_server.group }}"
+    mode: 0540
+  when: gocd_server.passwd_users
+
+- name: Ensure gocd server is running
+  sudo: yes
+  service:
+    name: go-server
+    state: started

--- a/templates/passwd.j2
+++ b/templates/passwd.j2
@@ -1,0 +1,6 @@
+##
+# {{ ansible_managed }}
+
+{% for name, passwd in gocd_server.passwd_users.iteritems() %}
+{{ name }}:{{ passwd }}
+{% endfor %}

--- a/tests/vagrant/ansible.cfg
+++ b/tests/vagrant/ansible.cfg
@@ -1,0 +1,2 @@
+[defaults]
+hash_behaviour = merge

--- a/tests/vagrant/test.yml
+++ b/tests/vagrant/test.yml
@@ -5,10 +5,12 @@
 
   pre_tasks:
     - name: Update apt
-      sudo: yes
-      command: apt-get update
+      become: yes
+      apt:
+        cache_valid_time: 1800
+        update_cache: yes
       tags:
         - build
 
   roles:
-    - role: ansible-city.gocd_server
+    - name: ansible-city.gocd_server

--- a/tests/vagrant/test.yml
+++ b/tests/vagrant/test.yml
@@ -11,4 +11,4 @@
         - build
 
   roles:
-    - ansible-city.gocd_server
+    - role: ansible-city.gocd_server


### PR DESCRIPTION
If you choose to manage users in gocd using passwd file, you can simply
pass to `gocd_server.passwd_users` a dictionary with users and "sha"
passwords.
