### PR TITLE
[GITHUB-7] Switch from git to ansible galaxy

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+The MIT License (MIT)
+
+Copyright (c) 2015 Voytek Solutions LTD
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/Makefile
+++ b/Makefile
@@ -3,6 +3,12 @@ BRANCH?=$(shell git rev-parse --abbrev-ref HEAD)
 
 all: test clean
 
+watch:
+	while sleep 1; do \
+		find defaults/ handlers/ meta/ tasks/ templates/ \
+		| entr -d make test; \
+	done
+
 test: test_deps vagrant_up
 
 integration_test: clean integration_test_deps vagrant_up clean

--- a/README.md
+++ b/README.md
@@ -1,7 +1,10 @@
 # GO CD Server
 
+Master: [![Build Status](https://travis-ci.org/ansible-city/gocd_server.svg?branch=master)](https://travis-ci.org/ansible-city/gocd_server)  
+Develop: [![Build Status](https://travis-ci.org/ansible-city/gocd_server.svg?branch=develop)](https://travis-ci.org/ansible-city/gocd_server)
+
 * [ansible.cfg](#ansible-cfg)
-* [Dependencies](#dependencies)
+* [Installation and Dependencies](#installation-and-dependencies)
 * [Tags](#tags)
 * [Examples](#examples)
 
@@ -25,19 +28,21 @@ hash_behaviour = merge
 
 
 
-## Dependencies
+## Installation and Dependencies
 
-To install dependencies, add this to your roles.yml
+This role has a "java" dependency. You can let this role install Oracle
+Java 7, or install it yourself and set `gocd_server.dependencies.skip_java`
+to `yes`.
+
+To install this role run `ansible-galaxy install ansible-city.gocd_server`
+or add this to your `roles.yml`
 
 ```YAML
----
-
 - name: ansible-city.gocd_server
-  src: git+git@github.com:ansible-city/gocd_server.git
-  version: origin/master # or any other tag/branch
+  version: v1.0
 ```
 
-and run `ansible-galaxy install -p . -r roles.yml`
+and run `ansible-galaxy install -p ./roles -r roles.yml`
 
 
 
@@ -68,7 +73,7 @@ To simply install GO CD server:
         - build
 
   roles:
-    - gocd_server
+    - name: ansible-city.gocd_server
 ```
 
 A bit more advanced playbook to install on a box with more then 4GB ram:

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -11,7 +11,7 @@ gocd_server:
   server_min_perm_gen: 128m
   user_dir: /home/go
   user: go
-  version: "14.4.*"
+  version: "15.3.*"
 
   dependencies:
     skip_java: no

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -15,8 +15,7 @@ galaxy_info:
 
 dependencies:
   - name: ansible-city.java
-    src: https://github.com/ansible-city/java.git
-    scm: git
+    version: v1.0
     tags:
       - build
     when: not gocd_server.dependencies.skip_java

--- a/tasks/configure.yml
+++ b/tasks/configure.yml
@@ -1,6 +1,6 @@
 ---
 
-- name: create various directories
+- name: Create various directories
   become: yes
   file:
     path: "{{ gocd_server.user_dir }}/{{ item }}"

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,11 +1,11 @@
 ---
 
-- name: install go server
+- name: Install go server
   include: build.yml
   tags:
     - build
 
-- name: install go server
+- name: Configure go server
   include: configure.yml
   tags:
     - configure

--- a/tests/vagrant/integration_requirements.yml
+++ b/tests/vagrant/integration_requirements.yml
@@ -1,5 +1,4 @@
 ---
 
 - name: ansible-city.gocd_server
-  src: git+git@github.com:ansible-city/gocd_server.git
-  version: origin/master
+  version: v1.0

--- a/tests/vagrant/local_requirements.yml
+++ b/tests/vagrant/local_requirements.yml
@@ -1,5 +1,4 @@
 ---
 
 - name: ansible-city.java
-  src: https://github.com/ansible-city/java.git
-  scm: git
+  version: v1.0


### PR DESCRIPTION
ansible-city roles are now published in Ansible-Galaxy now.
